### PR TITLE
Update github actions for RHM use cases

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,9 +19,11 @@ jobs:
 
       - name: build and push docker image
         run: |
-          echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+          echo "$DOCKER_PASSWORD" | docker login "$DOCKER_REPO.$DOCKER_HOST" -u "$DOCKER_USERNAME" --password-stdin
           VERSION=master make docker_push     # Push image tagged with "master"
           make docker_push                    # Push image tagged with git sha
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_REPO: ${{ secrets.DOCKER_REPO }}
+          DOCKER_HOST: ${{ secrets.DOCKER_HOST }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,8 +19,10 @@ jobs:
 
       - name: build and push docker image
         run: |
-          echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+          echo "$DOCKER_PASSWORD" | docker login "$DOCKER_REPO.$DOCKER_HOST" -u "$DOCKER_USERNAME" --password-stdin
           make docker_push
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          DOCKER_REPO: ${{ secrets.DOCKER_REPO }}
+          DOCKER_HOST: ${{ secrets.DOCKER_HOST }}


### PR DESCRIPTION
The PR allows the RHM team to specify specific docker repo to push images to.