### PR TITLE
Update github actions for RHM use cases

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,9 +19,10 @@ jobs:
 
       - name: build and push docker image
         run: |
-          echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+          echo "$DOCKER_PASSWORD" | docker login "$REGISTRY" -u "$DOCKER_USERNAME" --password-stdin
           VERSION=master make docker_push     # Push image tagged with "master"
           make docker_push                    # Push image tagged with git sha
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          REGISTRY: ${{ secrets.DOCKER_REGISTRY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,8 +19,9 @@ jobs:
 
       - name: build and push docker image
         run: |
-          echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+          echo "$DOCKER_PASSWORD" | docker login "$REGISTRY" -u "$DOCKER_USERNAME" --password-stdin
           make docker_push
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          REGISTRY: ${{ secrets.DOCKER_REGISTRY }}


### PR DESCRIPTION
This PR utilizes the REGISTRY setting to point to the RHM Docker Registry.  Additionally, the actions have been updated to authenticate to this registry.

https://github.com/redhat-marketplace/ratelimit/blob/9c22ef414e9a2724822112c3b73d52e76b0a788e/Makefile#L3-L4