### PR TITLE
feat: enhance TLS support by taking path to CA file for redis conn

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ bootstrap_redis_tls: redis.conf redis-per-second.conf
 	cat key.pem cert.pem > private.pem
 	sudo cp cert.pem /usr/local/share/ca-certificates/redis-stunnel.crt
 	chmod 640 key.pem cert.pem private.pem
-	sudo update-ca-certificates
+	#sudo update-ca-certificates - not needed with the RedisTlsCACerts feature
 	sudo stunnel redis.conf
 	sudo stunnel redis-per-second.conf
 .PHONY: docs_format

--- a/src/settings/settings.go
+++ b/src/settings/settings.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"time"
 
+	"github.com/envoyproxy/ratelimit/src/utils"
 	"github.com/kelseyhightower/envconfig"
 	"google.golang.org/grpc"
 )
@@ -58,6 +59,8 @@ type Settings struct {
 	RedisTls        bool   `envconfig:"REDIS_TLS" default:"false"`
 	// TODO: Make this setting configurable out of the box instead of having to provide it through code.
 	RedisTlsConfig *tls.Config
+	// Custom logic to allow CA Certs to be specified
+	RedisTlsCACerts string `envconfig:"REDIS_TLS_CA_CERTS" default:""`
 
 	// RedisPipelineWindow sets the duration after which internal pipelines will be flushed.
 	// If window is zero then implicit pipelining will be disabled. Radix use 150us for the
@@ -100,6 +103,13 @@ func NewSettings() Settings {
 	err := envconfig.Process("", &s)
 	if err != nil {
 		panic(err)
+	}
+
+	if s.RedisTlsCACerts != "" {
+		s.RedisTlsConfig, err = utils.GenerateTlsConfig(s.RedisTlsCACerts)
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	return s


### PR DESCRIPTION
This feature replaces the RedisTlsConfig code and takes a file path to a CA Certs file via a new environment variable called RedisTlsCACerts.  This file is then used to generate a tls.Config for the redis connection.

Majority of updates are unit test fixes to test negative cases and replace the _nil_ tls.Config object with an empty string.

In future, we could update this code to be able to take private key and cert for the client side of the mutual auth and plug them into the GetClientTLSConfig function.